### PR TITLE
Improved performance and CLI tool–Diable 2.1.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,16 +11,9 @@ Usage:
 // Daemonizes the current process
 Diable();
 
-// Daemonizes the current process by adding the '--foo bar' cli arguments.
-Diable({
-  args: {
-     "foo": "bar"
-  }
-});
-
-// Daemonizes a provided path
+// Daemonizes the current process with additional options
 Diable("path/to/some/script.js", {
-  // some options
+   args: ["some", "additional", "arguments"]
 });
 
 // Daemonizes a provided path
@@ -30,7 +23,8 @@ Diable("path/to/some/script.js", {
 
 // Daemonizes a different process handling the stdio streams
 Diable("", "some-command", {
-   stdio: [stdin, stdout, stderr]
+    stdout: process.stdout
+  , exit: false
 });
 ```
 
@@ -38,12 +32,16 @@ Diable("", "some-command", {
 - **String** `path`: The path to the script to daemonize (default: the current process path).
 - **String** `exec`: The executable to run (default: `process.execPath`).
 - **Object** `options`: An object which will be passed to the `exec` function. It is extended with:
- - `force` (Boolean): A flag to force daemonizing even the process is a daemon already (default: `false`).
- - `exit` (Boolean): A flag to control the process exit (default: `true`).
+ - `exit` (Boolean): A flag to control the process exit. If `false`, the parent process will not be closed.
  - `args` (Array): An array with the additional cli arguments.
+ - `stdout` (Stream): The stdout stream (default: `"ignore"`).
+ - `stderr` (Stream): The stderr stream (default: `"ignore"`).
+ - `env` (Object): The environment object (default: `process.env`).
+ - `cwd` (String): The working directory path (default: `process.cwd`).
+ - `force` (Boolean): If `true`, the daemonized process will be able to be daemonized.
 
 #### Return
-- **Null|Proc** `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is true.
+- **Number|Process** `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is `true`.
 
 ### `isDaemon()`
 Checks if the current process is a daemon started by `diable`.
@@ -51,12 +49,13 @@ Checks if the current process is a daemon started by `diable`.
 #### Return
 - **Boolean** `true` if the process is a daemon, `false` otherwise.
 
-### `daemonize(app, args, options)`
+### `daemonize(exec, path, args, options)`
 Low level for daemonizing the things. It's used internally.
 Also, it can be useful in specific cases.
 
 #### Params
-- **String** `app`: The executable application.
+- **String** `exec`: The executable application (defaults to the `process.execPath`).
+- **String** `path`: An optional node.js file path for convenience. This will be prepended to the `args` array.
 - **Array** `args`: The spawn arguments (default: `[]`).
 - **Object** `options`: The object passed to the `spawn` function (default: `{}`).
 

--- a/LICENSE
+++ b/LICENSE
@@ -25,7 +25,7 @@ You are encouraged to kindly support the software and its author by:
 
 ===============================================================================
 
-The code was heavily inspired from Charlie Robbins's node-daemon fork which is
-MIT-licensed: https://github.com/indexzero/daemon.node
+The code was heavily inspired from Charlie Robbins's daemon.node project which
+is MIT-licensed: https://github.com/indexzero/daemon.node
 
 So, big thanks! :)

--- a/LICENSE
+++ b/LICENSE
@@ -22,3 +22,10 @@ You are encouraged to kindly support the software and its author by:
  - reporting issues/bugs and asking for feature requests
  - donating money or any other things that can help the author
  - contribute on the software code by fixing bugs and adding features
+
+===============================================================================
+
+The code was heavily inspired from Charlie Robbins's node-daemon fork which is
+MIT-licensed: https://github.com/indexzero/daemon.node
+
+So, big thanks! :)

--- a/README.md
+++ b/README.md
@@ -44,14 +44,17 @@ var Diable = require("diable");
 
 // Check if we are already a daemon
 if (Diable.isDaemon()) {
-    return setTimeout(function () {
+    setTimeout(function () {
         console.log("I was alive for 10 seconds.");
     }, 10000);
+} else {
+    console.log("Daemonizing this process. I will be killed, but I have a child which will live 10 seconds. Do `ps aux | grep node` to see it.");
 }
 
-// Do the stuff
-console.log("Daemonizing this process. I will be killed, but I have a child which will live 10 seconds. Do `ps aux | grep node` to see it.");
+// Daemonize this process (only the non-daemons)
 Diable();
+
+console.log("I am a daemon.");
 
 ```
 

--- a/bin/diable
+++ b/bin/diable
@@ -11,6 +11,7 @@ var Diable = require("../lib")
 var pathOption = new Clp.Option(["p", "path"], "The script path.", "path")
   , execOption = new Clp.Option(["e", "exec"], "The executable app.", "app", "node")
   , argsOption = new Clp.Option(["a", "args"], "The arguments to pass.", "args")
+  , cwdOption = new Clp.Option(["c", "cwd"], "The CWD where the daemonized process will run.", "path")
   , parser = new Clp({
         name: "Diable"
       , version: Package.version
@@ -22,7 +23,7 @@ var pathOption = new Clp.Option(["p", "path"], "The script path.", "path")
           , "diable -p path/to/script.js -a '--some args'"
         ]
       , docs_url: Package.homepage
-    }, [pathOption, execOption, argsOption])
+    }, [pathOption, execOption, argsOption, cwdOption])
   ;
 
 // Parse the arguments
@@ -30,10 +31,15 @@ if (argsOption.value) {
     argsOption.value = argsOption.value.match(/"[^"]+"|'[^']+'|\S+/g);
 }
 
+if (Diable.isDaemon()) {
+    Logger.log("You are already a daemon. Unset the `__is_daemon` environment variable and try again.", "warn");
+    return;
+}
+
 // Daemonize a script
-if (pathOption.is_provided) {
-    var proc = Diable(pathOption.value, execOption.value, {
-        args: argsOption.value
+if (pathOption.value || execOption.value) {
+    var proc = Diable.daemonize(execOption.value, pathOption.value, argsOption.value, {
+        cwd: cwdOption.value
     });
     Logger.log("Daemonizing " + pathOption.value);
     Logger.log("Process id: " + proc.pid);

--- a/bin/diable
+++ b/bin/diable
@@ -18,19 +18,27 @@ var pathOption = new Clp.Option(["p", "path"], "The script path.", "path")
       , exe: Package.name
       , examples: [
             "diable -p path/to/script.js"
-          , "diable -p path/to/script.js -e iojs"
+          , "diable -p some-script.sh -e sh"
           , "diable -p path/to/script.js -a '--some args'"
         ]
-      , docs_url: "https://github.com/IonicaBizau/node-diable"
+      , docs_url: Package.homepage
     }, [pathOption, execOption, argsOption])
   ;
 
-// Daemonize a script
-if (pathOption.is_provided) {
-    Logger.log("Daemonizing " + pathOption.value);
-    return Diable(pathOption.value, execOption.value, {
-        args: argsOption.value
-    });
+// Parse the arguments
+if (argsOption.value) {
+    argsOption.value = argsOption.value.match(/"[^"]+"|'[^']+'|\S+/g);
 }
 
+// Daemonize a script
+if (pathOption.is_provided) {
+    var proc = Diable(pathOption.value, execOption.value, {
+        args: argsOption.value
+    });
+    Logger.log("Daemonizing " + pathOption.value);
+    Logger.log("Process id: " + proc.pid);
+    return;
+}
+
+// Output
 Logger.log("Please provide the path to the script to daemonize or a command to run. Run `diable -h` for help.", "error");

--- a/example/index.js
+++ b/example/index.js
@@ -3,11 +3,14 @@ var Diable = require("../lib");
 
 // Check if we are already a daemon
 if (Diable.isDaemon()) {
-    return setTimeout(function () {
+    setTimeout(function () {
         console.log("I was alive for 10 seconds.");
     }, 10000);
+} else {
+    console.log("Daemonizing this process. I will be killed, but I have a child which will live 10 seconds. Do `ps aux | grep node` to see it.");
 }
 
-// Do the stuff
-console.log("Daemonizing this process. I will be killed, but I have a child which will live 10 seconds. Do `ps aux | grep node` to see it.");
+// Daemonize this process (only the non-daemons)
 Diable();
+
+console.log("I am a daemon.");

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ Diable.daemonize = function (exec, app, args, options) {
       , stderr = options.stderr || "ignore"
       , env = options.env || process.env
       , cwd = options.cwd || process.cwd
-      , cp_opt = {
+      , cpOpt = {
             stdio: ["ignore", stdout, stderr]
           , env: env
           , cwd: cwd
@@ -134,9 +134,13 @@ Diable.daemonize = function (exec, app, args, options) {
       , proc = null
       ;
 
-    cp_opt.env.__is_daemon = true;
+    cpOpt.env.__is_daemon = true;
 
-    proc = Spawn(exec, [app].concat(args), cp_opt);
+    if (Typpy(app, String)) {
+        args = [app].concat(args);
+    }
+
+    proc = Spawn(exec, args, cpOpt);
     proc.unref();
 
     return proc;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // Dependencies
-var procProcess = require("child_process")
-  , Spawn = procProcess.spawn
+var ChildProcess = require("child_process")
+  , Spawn = ChildProcess.spawn
   , Typpy = require("typpy")
   ;
 
@@ -44,13 +44,14 @@ var procProcess = require("child_process")
  *  - `stderr` (Stream): The stderr stream (default: `"ignore"`).
  *  - `env` (Object): The environment object (default: `process.env`).
  *  - `cwd` (String): The working directory path (default: `process.cwd`).
+ *  - `force` (Boolean): If `true`, the daemonized process will be able to be daemonized.
  *
- * @return {Number|Process} `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is true.
+ * @return {Number|Process} `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is `true`.
  */
 function Diable(path, exec, options) {
 
     // The process is a daemon
-    if (Diable.isDaemon()) {
+    if (Diable.isDaemon() && !options.force) {
         return process.pid;
     }
 
@@ -112,7 +113,8 @@ Diable.isDaemon = function () {
  *
  * @name daemonize
  * @function
- * @param {String} app The executable application.
+ * @param {String} exec The executable application (defaults to the `process.execPath`).
+ * @param {String} path An optional node.js file path for convenience. This will be prepended to the `args` array.
  * @param {Array} args The spawn arguments (default: `[]`).
  * @param {Object} options The object passed to the `spawn` function (default: `{}`).
  * @return {Process} The daemon process.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 // Dependencies
-var ChildProcess = require("child_process")
-  , Spawn = ChildProcess.spawn
-  , Ul = require("ul")
+var procProcess = require("child_process")
+  , Spawn = procProcess.spawn
+  , Typpy = require("typpy")
   ;
 
 /**
@@ -15,16 +15,9 @@ var ChildProcess = require("child_process")
  * // Daemonizes the current process
  * Diable();
  *
- * // Daemonizes the current process by adding the '--foo bar' cli arguments.
- * Diable({
- *   args: {
- *      "foo": "bar"
- *   }
- * });
- *
- * // Daemonizes a provided path
+ * // Daemonizes the current process with additional options
  * Diable("path/to/some/script.js", {
- *   // some options
+ *    args: ["some", "additional", "arguments"]
  * });
  *
  * // Daemonizes a provided path
@@ -34,7 +27,8 @@ var ChildProcess = require("child_process")
  *
  * // Daemonizes a different process handling the stdio streams
  * Diable("", "some-command", {
- *    stdio: [stdin, stdout, stderr]
+ *     stdout: process.stdout
+ *   , exit: false
  * });
  * ```
  *
@@ -44,62 +38,56 @@ var ChildProcess = require("child_process")
  * @param {String} exec The executable to run (default: `process.execPath`).
  * @param {Object} options An object which will be passed to the `exec` function. It is extended with:
  *
- *  - `force` (Boolean): A flag to force daemonizing even the process is a daemon already (default: `false`).
- *  - `exit` (Boolean): A flag to control the process exit (default: `true`).
+ *  - `exit` (Boolean): A flag to control the process exit. If `false`, the parent process will not be closed.
  *  - `args` (Array): An array with the additional cli arguments.
+ *  - `stdout` (Stream): The stdout stream (default: `"ignore"`).
+ *  - `stderr` (Stream): The stderr stream (default: `"ignore"`).
+ *  - `env` (Object): The environment object (default: `process.env`).
+ *  - `cwd` (String): The working directory path (default: `process.cwd`).
  *
- * @return {Null|Proc} `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is true.
+ * @return {Number|Process} `null` if the process was not daemonized, the daemon process otherwise. A daemon cannot be daemonized by itself unless `options.force` is true.
  */
 function Diable(path, exec, options) {
 
-    // Diable(options);
-    if (typeof path === "object") {
-        options = path;
+    // The process is a daemon
+    if (Diable.isDaemon()) {
+        return process.pid;
+    }
+
+    // Diable({...})
+    if (Typpy(path, Object)) {
+        options = exec;
         path = null;
-    // Diable(path, options);
-    } else if (typeof exec === "object") {
+    }
+
+    // Diable("script.js", {...})
+    if (Typpy(exec, Object)) {
         options = exec;
         exec = null;
     }
 
-    // Get the script path
-    path = typeof path === "string" ? path : process.argv[1];
+    // Defaults
+    options = options || {};
+    var args = [].concat(process.argv)
+      , proc = null
+      , script = null
+      ;
 
-    // Get the exec path
-    exec = exec || process.execPath;
-
-    // Merge the options
-    options = Ul.deepMerge(options, {
-        args: []
-      , detached: true
-      , cwd: process.cwd()
-      , force: false
-      , exit: true
-      , env: Ul.merge(process.env, {
-            __is_daemon: true
-        })
-    });
-
-    // Check if the process is already a daemon
-    if (!options.force && path === process.argv[1] && Diable.isDaemon()) {
-        return null;
+    // Concat optional args
+    if (Array.isArray(options.args)) {
+        args = args.concat(options.args);
     }
 
-    var opts = {
-        exit: options.exit
-      , force: options.force
-      , args: options.args
-    };
+    // Prepare data
+    args.shift();
+    script = path || args.shift();
 
-    delete options.exit;
-    delete options.force;
-    delete options.args;
+    // Daemonize the process
+    proc = Diable.daemonize(exec || process.execPath, script, args, options);
 
-    var proc = Diable.daemonize(exec, [path].concat(opts.args).filter(function (c) {
-        return c !== null;
-    }), options);
-    if (opts.exit || (path === process.argv[1] && opts.exit)) {
-        process.exit();
+    // Do not exit
+    if (options.exit !== false) {
+        process.nextTick(process.exit);
     }
 
     return proc;
@@ -114,7 +102,7 @@ function Diable(path, exec, options) {
  * @return {Boolean} `true` if the process is a daemon, `false` otherwise.
  */
 Diable.isDaemon = function () {
-    return process.env.__is_daemon ? true : false;
+    return !!process.env.__is_daemon;
 };
 
 /**
@@ -129,11 +117,28 @@ Diable.isDaemon = function () {
  * @param {Object} options The object passed to the `spawn` function (default: `{}`).
  * @return {Process} The daemon process.
  */
-Diable.daemonize = function (app, args, options) {
-    args = args || [];
+Diable.daemonize = function (exec, app, args, options) {
+
     options = options || {};
-    var proc = Spawn(app, args, options);
+
+    var stdout = options.stdout || "ignore"
+      , stderr = options.stderr || "ignore"
+      , env = options.env || process.env
+      , cwd = options.cwd || process.cwd
+      , cp_opt = {
+            stdio: ["ignore", stdout, stderr]
+          , env: env
+          , cwd: cwd
+          , detached: true
+        }
+      , proc = null
+      ;
+
+    cp_opt.env.__is_daemon = true;
+
+    proc = Spawn(exec, [app].concat(args), cp_opt);
     proc.unref();
+
     return proc;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ function Diable(path, exec, options) {
     script = path || args.shift();
 
     // Daemonize the process
-    proc = Diable.daemonize(exec || process.execPath, script, args, options);
+    proc = Diable.daemonize(exec, script, args, options);
 
     // Do not exit
     if (options.exit !== false) {
@@ -139,6 +139,8 @@ Diable.daemonize = function (exec, app, args, options) {
     if (Typpy(app, String)) {
         args = [app].concat(args);
     }
+
+    exec = exec || process.execPath;
 
     proc = Spawn(exec, args, cpOpt);
     proc.unref();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "bug-killer": "^4.0.0",
     "clp": "^3.0.0",
-    "oargv": "^2.0.0",
     "ul": "^5.0.0"
   },
   "blah": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:IonicaBizau/diable.git"
+    "url": "git@github.com/IonicaBizau/diable.git"
   },
   "keywords": [
     "daemon",
@@ -31,12 +31,13 @@
   "devDependencies": {
     "mocha": "^2.2.4"
   },
+  "blah": {
+    "h_img": "http://i.imgur.com/i0aopxe.png"
+  },
   "dependencies": {
     "bug-killer": "^4.0.0",
     "clp": "^3.0.0",
+    "typpy": "^2.1.0",
     "ul": "^5.0.0"
-  },
-  "blah": {
-    "h_img": "http://i.imgur.com/i0aopxe.png"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diable",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Daemonize the things out.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Got some inspiration from @indexzero [daemon.node](https://github.com/indexzero/daemon.node) project and improved the things. Big thanks! :cake: 

Improved the command line tool as well:

```sh
$ ./bin/diable -h
Usage: diable [options]

Options:
  -p, --path <path>  The script path.
  -e, --exec <app>   The executable app.
  -a, --args <args>  The arguments to pass.
  -c, --cwd <path>   The CWD where the daemonized process will run.
  -h, --help         Displays this help.
  -v, --version      Displays version information.

Examples:
  diable -p path/to/script.js
  diable -p some-script.sh -e sh
  diable -p path/to/script.js -a '--some args'

Documentation can be found at https://github.com/IonicaBizau/diable
```

The things are smoother now! :star2: 