### PR TITLE
fix: default value of cwd should be a string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
     - 4
+    - 6
+    - 8
+    - 9

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ Diable.daemonize = function (script, args, opts) {
     var stdout = opts.stdout || "ignore",
         stderr = opts.stderr || "ignore",
         env = opts.env || process.env,
-        cwd = opts.cwd || process.cwd;
+        cwd = opts.cwd || process.cwd();
 
     env.__is_daemon = true;
 


### PR DESCRIPTION
This seemed to work on Node 4 and 6
but fails on 8 and 9

ref https://github.com/pnpm/pnpm/pull/995

I noticed the error when I wanted to use diable for a new pnpm feature